### PR TITLE
Fix paths on windows environment

### DIFF
--- a/lib/node/index.ts
+++ b/lib/node/index.ts
@@ -54,6 +54,7 @@ function plugin(options: Options = {}): Plugin {
   } = options;
 
   const dir = path.resolve(process.cwd(), appDirectory);
+  const prefix = `.${path.sep}${path.relative(process.cwd(), dir)}`;
 
   if (
     !fs.existsSync(path.join(dir, "routes")) ||
@@ -67,7 +68,6 @@ function plugin(options: Options = {}): Plugin {
     );
   }
 
-  const prefix = `/${path.sep}${path.relative(process.cwd(), dir)}`;
 
   return {
     name: "vite-plugin-remix-routes",

--- a/lib/node/index.ts
+++ b/lib/node/index.ts
@@ -67,7 +67,7 @@ function plugin(options: Options = {}): Plugin {
     );
   }
 
-  const prefix = `.${path.sep}${path.relative(process.cwd(), dir)}`;
+  const prefix = `/${path.sep}${path.relative(process.cwd(), dir)}`;
 
   return {
     name: "vite-plugin-remix-routes",

--- a/lib/node/remix.ts
+++ b/lib/node/remix.ts
@@ -76,6 +76,7 @@ export async function getRoutes(options: GetRouteOptions) {
   // This is not part of remix.
   const modifyRoute = (route: Route): Route => ({
     ...route,
+    file: route.file.replace(/\\/g, '/'),
     path: !dataRouterCompatible && is404Route(route) ? "*" : route.path,
     children: route.children.map(modifyRoute),
   });

--- a/lib/node/remix.ts
+++ b/lib/node/remix.ts
@@ -76,7 +76,6 @@ export async function getRoutes(options: GetRouteOptions) {
   // This is not part of remix.
   const modifyRoute = (route: Route): Route => ({
     ...route,
-    file: route.file.replace(/\\/g, '/'),
     path: !dataRouterCompatible && is404Route(route) ? "*" : route.path,
     children: route.children.map(modifyRoute),
   });

--- a/lib/node/utils.ts
+++ b/lib/node/utils.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { Route } from "./remix";
 
 export type RequireOnly<Object, Keys extends keyof Object> = Omit<
@@ -44,9 +45,11 @@ function routeToString(
   context: Context,
   components: Components
 ): string {
-  const componentName = getRouteComponentName(route);
-  const componentPath = `${context.prefix}/${route.file}`;
   const importMode = context.importMode?.(route) || "sync";
+  const componentName = getRouteComponentName(route);
+  const componentPath = `${context.prefix}${path.sep}${route.file}`
+    .split(path.sep)
+    .join(path.posix.sep);
 
   const props = new Map<string, string>();
 


### PR DESCRIPTION
Using the plugin on windows environments there are a couple of issues with the paths. Windows uses the path separator `\` but the plugin is generating a virtual js file for Node, which uses `/` as a path generator.

On windows we can see the problem on the paths:

<img width="897" alt="Screenshot 2022-10-28 at 13 58 43" src="https://user-images.githubusercontent.com/24297787/198583581-dd3caf3d-dfc7-4579-b9fa-5b438d8efcf3.png">

On one side, the prefix is generated in the library, so it can be easily modified.
On the other hand, the Remix defineConventionalRoutes provides the routes already with the `\` separator, so we need to modify it with a string replacement.

The result of these 2 modifications is:

<img width="717" alt="Screenshot 2022-10-28 at 13 58 17" src="https://user-images.githubusercontent.com/24297787/198583826-12cd39a6-f20d-43fb-ad9a-68545b2b0ae2.png">
