### PR TITLE
fix react peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "vitest": "^0.24.3"
   },
   "peerDependencies": {
-    "react": "^16.6.0",
+    "react": ">=16.6",
     "react-router-dom": "^6.4.2"
   },
   "files": [


### PR DESCRIPTION
Updates the react peer dependency to match react-router's and allow for usage with react 17/18.
Motivation/Reproduction:
At the moment installing this plugin with react 18 in a recent version of npm throws a peer dep error.